### PR TITLE
feat: add optional support for log facade

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -32,6 +32,8 @@ grind_signatures = []
 
 default = ["std", "grind_signatures"]
 
+facade = ["log"]
+
 [dependencies]
 lightning-types = { version = "0.3.0", path = "../lightning-types", default-features = false }
 lightning-invoice = { version = "0.34.0", path = "../lightning-invoice", default-features = false }
@@ -49,6 +51,7 @@ backtrace = { version = "0.3", optional = true }
 
 libm = { version = "0.2", default-features = false }
 inventory = { version = "0.3", optional = true  }
+log = { version = "*", optional = true, default-features = false, features = ["kv", "std"] }
 
 [dev-dependencies]
 regex = "1.5.6"


### PR DESCRIPTION
## What this PR does
This PR adds optional support for the `log` facade by implementing a concrete 
adapter that wraps an inner `Logger`.

This approach introduces the least amount of changes, respects the maintainers
wishes to only introduce additive changes that do not modify the internal `Logger`
trait and accompanying macros, and delegates logging to the internal `Logger`.

The adapter, initialization function, and `log` macros are made available via the cargo 
feature `facade`.

We enable the `kv` feature on `log` to enable users/callers enrich the log facade `Record` 
with key-value pairs, extracting and then transmit them to the internal `Record`.